### PR TITLE
fix: introduction dynamicText typo

### DIFF
--- a/src/components/home/IntroductionSection.jsx
+++ b/src/components/home/IntroductionSection.jsx
@@ -9,11 +9,11 @@ function IntroductionSection() {
     const theme = useTheme();
 
     const dynamicTexts = [
-        'Scalable App Builder',
+        'a Scalable App Builder',
         'Driven to Deliver',
-        'Fast Learner, Faster Builder',
-        'Rapid Prototyper',
-        'Aspiring Entrepreneur',
+        'a Fast Learner, Faster Builder',
+        'a Rapid Prototyper',
+        'an Aspiring Entrepreneur',
     ];
 
     return (
@@ -23,7 +23,7 @@ function IntroductionSection() {
             </Typography>
             <Box sx={{ display: 'flex', alignItems: 'center', marginTop: '1rem' }}>
                 <Typography variant="h4" sx={{ color: 'white', marginRight: '1rem' }}>
-                    I'm a
+                    I'm
                 </Typography>
                 <motion.div
                     initial={{ opacity: 0, y: 20 }}


### PR DESCRIPTION
- IntroductionSection.jsx dynamicTexts display window started with "I'm a" which is not applicable to every dynamic text. Now it starts with "I'm" and the relevant article is attached the dynamicText itself.